### PR TITLE
feat: add compact output format for task list command

### DIFF
--- a/scripts/modules/task-manager/list-tasks.js
+++ b/scripts/modules/task-manager/list-tasks.js
@@ -968,6 +968,25 @@ function generateMarkdownOutput(data, filteredTasks, stats) {
 }
 
 /**
+ * Format dependencies for compact output with truncation and coloring
+ * @param {Array} dependencies - Array of dependency IDs
+ * @returns {string} - Formatted dependency string with arrow prefix
+ */
+function formatCompactDependencies(dependencies) {
+	if (!dependencies || dependencies.length === 0) {
+		return '';
+	}
+	
+	if (dependencies.length > 5) {
+		const visible = dependencies.slice(0, 5).join(',');
+		const remaining = dependencies.length - 5;
+		return ` → ${chalk.cyan(visible)}${chalk.gray('... (+' + remaining + ' more)')}`;
+	} else {
+		return ` → ${chalk.cyan(dependencies.join(','))}`;
+	}
+}
+
+/**
  * Format a single task in compact one-line format
  * @param {Object} task - Task object
  * @param {number} maxTitleLength - Maximum title length before truncation
@@ -989,17 +1008,8 @@ function formatCompactTask(task, maxTitleLength = 50) {
 	};
 	const priorityColor = priorityColors[priority] || chalk.white;
 	
-	// Format dependencies
-	let depsText = '';
-	if (task.dependencies && task.dependencies.length > 0) {
-		if (task.dependencies.length > 5) {
-			const visible = task.dependencies.slice(0, 5).join(',');
-			const remaining = task.dependencies.length - 5;
-			depsText = ` → ${chalk.cyan(visible)}${chalk.gray('... (+' + remaining + ' more)')}`;
-		} else {
-			depsText = ` → ${chalk.cyan(task.dependencies.join(','))}`;
-		}
-	}
+	// Format dependencies using shared helper
+	const depsText = formatCompactDependencies(task.dependencies);
 	
 	return `${chalk.cyan(task.id)} ${coloredStatus} ${chalk.white(title)} ${priorityColor('(' + priority + ')')}${depsText}`;
 }
@@ -1018,17 +1028,8 @@ function formatCompactSubtask(subtask, parentId, maxTitleLength = 47) {
 	// Use colored status from existing function
 	const coloredStatus = getStatusWithColor(status, true);
 	
-	// Format dependencies
-	let depsText = '';
-	if (subtask.dependencies && subtask.dependencies.length > 0) {
-		if (subtask.dependencies.length > 5) {
-			const visible = subtask.dependencies.slice(0, 5).join(',');
-			const remaining = subtask.dependencies.length - 5;
-			depsText = ` → ${chalk.cyan(visible)}${chalk.gray('... (+' + remaining + ' more)')}`;
-		} else {
-			depsText = ` → ${chalk.cyan(subtask.dependencies.join(','))}`;
-		}
-	}
+	// Format dependencies using shared helper
+	const depsText = formatCompactDependencies(subtask.dependencies);
 	
 	return `  ${chalk.cyan(parentId + '.' + subtask.id)} ${coloredStatus} ${chalk.dim(title)}${depsText}`;
 }

--- a/tests/unit/scripts/modules/task-manager/list-tasks.test.js
+++ b/tests/unit/scripts/modules/task-manager/list-tasks.test.js
@@ -588,14 +588,15 @@ describe('listTasks', () => {
 	describe('Compact output format', () => {
 		test('should output compact format when outputFormat is compact', async () => {
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+			const tasksPath = 'tasks/tasks.json';
 
 			await listTasks(
-				mockTasksPath,
+				tasksPath,
 				null,
 				null,
 				false,
 				'compact',
-				mockContext
+				{ tag: 'master' }
 			);
 
 			expect(consoleSpy).toHaveBeenCalled();
@@ -609,14 +610,15 @@ describe('listTasks', () => {
 
 		test('should format single task compactly', async () => {
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+			const tasksPath = 'tasks/tasks.json';
 
 			await listTasks(
-				mockTasksPath,
+				tasksPath,
 				null,
 				null,
 				false,
 				'compact',
-				mockContext
+				{ tag: 'master' }
 			);
 
 			expect(consoleSpy).toHaveBeenCalled();
@@ -631,14 +633,15 @@ describe('listTasks', () => {
 
 		test('should handle compact format with subtasks', async () => {
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+			const tasksPath = 'tasks/tasks.json';
 
 			await listTasks(
-				mockTasksPath,
+				tasksPath,
 				null,
 				null,
 				true, // withSubtasks = true
 				'compact',
-				mockContext
+				{ tag: 'master' }
 			);
 
 			expect(consoleSpy).toHaveBeenCalled();
@@ -652,16 +655,17 @@ describe('listTasks', () => {
 		});
 
 		test('should handle empty task list in compact format', async () => {
-			mockReadJSON.mockReturnValue({ tasks: [] });
+			readJSON.mockReturnValue({ tasks: [] });
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+			const tasksPath = 'tasks/tasks.json';
 
 			await listTasks(
-				mockTasksPath,
+				tasksPath,
 				null,
 				null,
 				false,
 				'compact',
-				mockContext
+				{ tag: 'master' }
 			);
 
 			expect(consoleSpy).toHaveBeenCalledWith('No tasks found');
@@ -697,16 +701,17 @@ describe('listTasks', () => {
 				]
 			};
 
-			mockReadJSON.mockReturnValue(tasksWithDeps);
+			readJSON.mockReturnValue(tasksWithDeps);
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+			const tasksPath = 'tasks/tasks.json';
 
 			await listTasks(
-				mockTasksPath,
+				tasksPath,
 				null,
 				null,
 				false,
 				'compact',
-				mockContext
+				{ tag: 'master' }
 			);
 
 			expect(consoleSpy).toHaveBeenCalled();

--- a/tests/unit/scripts/modules/task-manager/list-tasks.test.js
+++ b/tests/unit/scripts/modules/task-manager/list-tasks.test.js
@@ -668,5 +668,58 @@ describe('listTasks', () => {
 			
 			consoleSpy.mockRestore();
 		});
+
+		test('should format dependencies correctly with shared helper', async () => {
+			// Create mock tasks with various dependency scenarios
+			const tasksWithDeps = {
+				tasks: [
+					{
+						id: 1,
+						title: 'Task with no dependencies',
+						status: 'pending',
+						priority: 'medium',
+						dependencies: []
+					},
+					{
+						id: 2,
+						title: 'Task with few dependencies',
+						status: 'pending',
+						priority: 'high',
+						dependencies: [1, 3]
+					},
+					{
+						id: 3,
+						title: 'Task with many dependencies',
+						status: 'pending',
+						priority: 'low',
+						dependencies: [1, 2, 4, 5, 6, 7, 8, 9]
+					}
+				]
+			};
+
+			mockReadJSON.mockReturnValue(tasksWithDeps);
+			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+			await listTasks(
+				mockTasksPath,
+				null,
+				null,
+				false,
+				'compact',
+				mockContext
+			);
+
+			expect(consoleSpy).toHaveBeenCalled();
+			const output = consoleSpy.mock.calls.map(call => call[0]).join('\n');
+			
+			// Should not show dependencies for task with empty deps
+			expect(output).toContain('1 [pending] Task with no dependencies (medium)');
+			// Should show all dependencies for few deps
+			expect(output).toMatch(/2.*→.*1,3/);
+			// Should truncate many dependencies
+			expect(output).toMatch(/3.*→.*1,2,4,5,6.*\(\+3 more\)/);
+			
+			consoleSpy.mockRestore();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds a new `--compact` flag to the `task-master list` command that provides a minimal, space-efficient output format ideal for quick scanning and terminal workflows.

## Changes

- **New `--compact` flag**: Enables minimal output format via `task-master list --compact` 
- **Compact formatting logic**: Clean, readable single-line format showing `ID [status] title (priority)`
- **Dependency formatting**: Shared helper with truncation for long dependency lists
- **Comprehensive test coverage**: Full test suite for compact format functionality

## Examples

**Standard output:**
```
Project Dashboard: Test Project
Progress: ████████░░ 80% (4/5 tasks completed)

Tasks:
├── [✅] 1: Setup Project (high)
├── [🔄] 2: Implement Core Features (high) → depends on: 1
└── [⏸️] 3: Create UI Components (medium) → depends on: 1,2
```

**Compact output:**
```
1 [done] Setup Project (high)
2 [pending] Implement Core Features (high) → 1
3 [in-progress] Create UI Components (medium) → 1,2
```

## Technical Details

- Maintains full backward compatibility
- Reuses existing task filtering and status logic
- Implements efficient dependency truncation (shows first 5, then "... (+N more)")
- Follows established CLI patterns and conventions

## Test Coverage

- Compact format output validation
- Dependency formatting with various scenarios
- Subtask handling with proper indentation
- Empty task list handling
- Integration with existing filtering options

🤖 Generated with [Claude Code](https://claude.ai/code)